### PR TITLE
Replace moment bower dependency with npm

### DIFF
--- a/addon/services/ticktock.js
+++ b/addon/services/ticktock.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import moment from 'moment';
 const { getOwner } = Ember;
 
 export default Ember.Service.extend({

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "ember": "~2.4.1",
     "ember-cli-shims": "0.1.0",
     "ember-cli-test-loader": "0.2.2",
-    "ember-qunit-notifications": "0.1.0",
-    "moment": "~2.11.1"
+    "ember-qunit-notifications": "0.1.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -2,9 +2,5 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-tick-tock',
-  included: function(app) {
-    this._super.included(app);
-    app.import(app.bowerDirectory + '/moment/min/moment.min.js');
-  }
+  name: 'ember-tick-tock'
 };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-htmlbars-inline-precompile": "^0.3.1",
     "ember-cli-inject-live-reload": "^1.3.1",
+    "ember-cli-moment-shim": "^3.0.0",
     "ember-cli-qunit": "^1.2.1",
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.0.0",
@@ -40,7 +41,8 @@
     "ember-load-initializers": "^0.5.0",
     "ember-resolver": "^2.0.3",
     "ember-try": "~0.0.8",
-    "loader.js": "^4.0.0"
+    "loader.js": "^4.0.0",
+    "moment": "^2.13.0"
   },
   "keywords": [
     "ember-addon"


### PR DESCRIPTION
The bower dependency is causing some problems when using ember-tick-tock together with the npm module, i.e. together with ember-moment setting the timezone is not possible. As everyone is moving away from bower this pr removes the bower dependency and adds the moment shim via npm. So ember-tick-tock and ember-moment can work together flawless for me and changing options and settings of moment shows the desired effects.